### PR TITLE
add haproxy for routing traffic & set limit size per volume

### DIFF
--- a/stamfordcenter/docker-compose.dev.yaml
+++ b/stamfordcenter/docker-compose.dev.yaml
@@ -3,12 +3,22 @@ networks:
   stamford:
 
 services:
-  # frontend
-  frontend:
-    image: lxkas/stamfordcenter-frontend
+
+  haproxy:
+    image: haproxy
     restart: always
     ports:
-      - 80:3000
+      - 443:443
+      - 80:80
+    volumes:
+      - ./haproxy:/usr/local/etc/haproxy
+    networks:
+      - stamford
+
+  # frontend
+  frontend:
+    image: ghcr.io/stamford-syntax-club/stamfordcenter-frontend:e6420ffb88d4c170af0ae691079f37be3b7b7e0c
+    restart: always
     networks:
       - stamford
 

--- a/stamfordcenter/docker-compose.dev.yaml
+++ b/stamfordcenter/docker-compose.dev.yaml
@@ -65,7 +65,7 @@ services:
       - 9333:9333 
       - 19333:19333 
       - 9324:9324
-    command: "master -ip=s3-master -ip.bind=0.0.0.0 -volumePreallocate=false -metricsPort=9324"
+    command: "master -ip=s3-master -ip.bind=0.0.0.0  -volumeSizeLimitMB=5 -volumePreallocate=false -metricsPort=9324 -mdir=/data"
     volumes:
       - ./data/master:/data
     networks:
@@ -78,7 +78,7 @@ services:
       - 8181:8181 
       - 18080:18080 
       - 9325:9325 
-    command: 'volume -mserver="s3-master:9333" -ip.bind=0.0.0.0 -port=8181 -metricsPort=9325'
+    command: 'volume -mserver="s3-master:9333" -ip.bind=0.0.0.0 -port=8181 -max=0 -metricsPort=9325 -dir=/data'
     depends_on:
       - s3-master
     volumes:
@@ -93,7 +93,7 @@ services:
       - 8888:8888 
       - 18888:18888
       - 9326:9326 
-    command: 'filer -master="s3-master:9333" -ip.bind=0.0.0.0 -metricsPort=9326'
+    command: 'filer -master="s3-master:9333" -ip.bind=0.0.0.0 -metricsPort=9326 -defaultStoreDir=/data'
     tty: true
     stdin_open: true
     depends_on:

--- a/stamfordcenter/docker-compose.dev.yaml
+++ b/stamfordcenter/docker-compose.dev.yaml
@@ -21,7 +21,7 @@ services:
     restart: always
     networks:
       - stamford
-
+      
   # api-gateway
 
   # backend

--- a/stamfordcenter/haproxy/haproxy.cfg
+++ b/stamfordcenter/haproxy/haproxy.cfg
@@ -1,0 +1,22 @@
+defaults
+    mode http
+    timeout connect 10s
+    timeout server 100s
+
+# frontend - client traffic
+frontend client
+    bind *:80
+    bind *:443 ssl crt /etc/letsencrypt/live/stamford.dev/haproxy.pem
+
+    acl is_center hdr_beg(host) -i center. # center.stamford.dev
+    acl is_prometheus hdr_beg(host) -i prometheus. # prometheus.stamford.dev
+    
+    use_backend center-fe if is_center
+    use_backend prometheus if is_prometheus
+
+# backend - where haproxy sends traffic to
+backend center-fe
+    server fe1 frontend:3000
+
+backend prometheus
+    server prom prometheus:9090

--- a/stamfordcenter/haproxy/haproxy.cfg
+++ b/stamfordcenter/haproxy/haproxy.cfg
@@ -1,12 +1,13 @@
 defaults
     mode http
+    timeout client 60s
     timeout connect 10s
     timeout server 100s
 
 # frontend - client traffic
 frontend client
     bind *:80
-    bind *:443 ssl crt /etc/letsencrypt/live/stamford.dev/haproxy.pem
+
 
     acl is_center hdr_beg(host) -i center. # center.stamford.dev
     acl is_prometheus hdr_beg(host) -i prometheus. # prometheus.stamford.dev


### PR DESCRIPTION
haproxy: 
- perform SSL Termination
- `center.stamford.dev` will route traffic to frontend container (can add more here for loadbalancing)
- `prometheus.stamford.dev` will route traffic to prometheus container


s3 volume:
- the s3 volume allocation algorithm essentially assigns `7` volumes (regardless the size) whenever it feels the need
- the default volume size limit is 1GB and our vm has around 11GB left in storage, we only have around 10 volumes available for allocating to buckets - this is not enough for the algorithm to work smoothly
- the workaround is to let size limit for each volume to be very low, so we can have more available volumes for the algorithm to allocate more freely


