### PR TITLE
add authentication for s3 api server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 */.env
 admin/stacks
+s3/config.json

--- a/s3/README.md
+++ b/s3/README.md
@@ -1,53 +1,79 @@
 # S3
 
+## Prerequisites
+
+Setup your credentials
+
+```
+aws configure
+```
+
+Please contact @chinathaip to retrieve the credentials
+
 ## Getting started
+
 Create new S3 Bucket
+
 ```
 aws s3 mb s3://<bucket-name> --endpoint-url http://localhost:8333
 ```
+
 See all buckets
+
 ```
 aws s3 ls --endpoint-url http://localhost:8333
 ```
+
 Upload file to S3
+
 ```
 aws s3 cp <target-path> s3://<bucket-name>/<desired-path> --endpoint-url http://localhost:8333
 ```
+
 Retrieve file from S3
+
 ```
 aws s3 cp s3://<bucket-name>/<target-path> <desired-path> --endpoint-url http://localhost:8333
 ```
+
 ### Note
+
 - this storage system uses mounted volume on host machine (named as `data`)\
 - remove folder `data` to empty the storage system
 
 ## Services
+
 ### S3
+
 - This service runs the SeaweedFS S3 server.
-- The S3 server provides an Amazon S3-compatible interface to interact with 
-SeaweedFS.
+- The S3 server provides an Amazon S3-compatible interface to interact with
+  SeaweedFS.
 - The Prometheus metrics are exposed on port 9327.
 - Access via `http://localhost:8333`
 
 ### S3-master
+
 - This service runs the SeaweedFS Master server.
 - The master server is responsible for managing the metadata and coordinating the volume servers.
 - It exposes ports 9333 for HTTP and 19333 for gRPC communication.
 - The Prometheus metrics are exposed on port 9324.
 
 ### S3-volume
+
 - This service runs the SeaweedFS Volume server.
 - The volume server stores the actual file data and is managed by the master server.
 - It exposes ports 8181 for HTTP and 18080 for gRPC communication.
 - The Prometheus metrics are exposed on port 9325.
 
 ### S3-filer
+
 - This service runs the SeaweedFS Filer server.
 - The filer server provides the file system-like interface to access the data stored in the volume servers.
 - It exposes ports 8888 for HTTP and 18888 for gRPC communication.
 - The Prometheus metrics are exposed on port 9326.
 
 ### S3-webdav:
+
 - This service runs the SeaweedFS WebDAV server.
 - The WebDAV server provides a WebDAV-compatible interface to access the data stored in SeaweedFS.
 - It exposes port 7333 for HTTP communication.

--- a/s3/config.example.json
+++ b/s3/config.example.json
@@ -1,0 +1,50 @@
+{
+	"identities": [
+		{
+			"name": "some_name",
+			"credentials": [
+				{
+					"accessKey": "some_access_key1",
+					"secretKey": "some_secret_key1"
+				}
+			],
+			"actions": [
+				"Admin",
+				"Read",
+				"ReadAcp",
+				"List",
+				"Tagging",
+				"Write",
+				"WriteAcp"
+			]
+		},
+		{
+			"name": "some_read_only_user",
+			"credentials": [
+				{
+					"accessKey": "some_access_key2",
+					"secretKey": "some_secret_key2"
+				}
+			],
+			"actions": [
+				"Read",
+				"List"
+			]
+		},
+		{
+			"name": "some_normal_user",
+			"credentials": [
+				{
+					"accessKey": "some_access_key3",
+					"secretKey": "some_secret_key3"
+				}
+			],
+			"actions": [
+				"Read",
+				"List",
+				"Tagging",
+				"Write"
+			]
+		}
+	]
+}

--- a/s3/docker-compose.dev.yaml
+++ b/s3/docker-compose.dev.yaml
@@ -9,8 +9,8 @@ services:
     image: chrislusf/seaweedfs
     restart: on-failure
     ports:
-      - 9333:9333 
-      - 19333:19333 
+      - 9333:9333
+      - 19333:19333
       - 9324:9324
     command: "master -ip=s3-master -ip.bind=0.0.0.0  -volumeSizeLimitMB=5 -volumePreallocate=false -metricsPort=9324 -mdir=/data"
     volumes:
@@ -22,9 +22,9 @@ services:
     image: chrislusf/seaweedfs
     restart: on-failure
     ports:
-      - 8181:8181 
-      - 18080:18080 
-      - 9325:9325 
+      - 8181:8181
+      - 18080:18080
+      - 9325:9325
     command: 'volume -mserver="s3-master:9333" -ip.bind=0.0.0.0 -port=8181 -max=0 -metricsPort=9325 -dir=/data'
     depends_on:
       - s3-master
@@ -37,9 +37,9 @@ services:
     image: chrislusf/seaweedfs
     restart: on-failure
     ports:
-      - 8888:8888 
+      - 8888:8888
       - 18888:18888
-      - 9326:9326 
+      - 9326:9326
     command: 'filer -master="s3-master:9333" -ip.bind=0.0.0.0 -metricsPort=9326 -defaultStoreDir=/data'
     tty: true
     stdin_open: true
@@ -55,9 +55,11 @@ services:
     image: chrislusf/seaweedfs
     restart: on-failure
     ports:
-      - 8333:8333 
-      - 9327:9327 
-    command: 's3 -filer="s3-filer:8888" -ip.bind=0.0.0.0 -metricsPort=9327'
+      - 8333:8333
+      - 9327:9327
+    command: 's3 -config=/conf/config.json -filer="s3-filer:8888" -ip.bind=0.0.0.0 -metricsPort=9327'
+    volumes:
+      - ./config.json:/conf/config.json
     depends_on:
       - s3-master
       - s3-volume


### PR DESCRIPTION
AppSmith requires us to setup authentication for our s3 api server.

only the matching credentials declared in `config.json` are allowed to access

example configuration can be seen in `config.example.json`

We will create a shared account to use in appsmith + backend application

Credentials can be configured via command line: `aws configure`