### PR TITLE
configure HAProxy Rate Limiting & clean docker compose files & add direct files retrieval endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 **/data
 .DS_Store
-*/.env
+*/.env**
 admin/stacks
 s3/config.json
 */.env.*

--- a/haproxy/docker-compose.dev.yaml
+++ b/haproxy/docker-compose.dev.yaml
@@ -6,6 +6,7 @@ networks:
 services:
   haproxy:
     image: haproxy
+    container_name: haproxy
     restart: always
     ports:
       - 443:443

--- a/haproxy/docker-compose.prod.yaml
+++ b/haproxy/docker-compose.prod.yaml
@@ -6,6 +6,7 @@ networks:
 services:
   haproxy:
     image: haproxy
+    container_name: haproxy
     restart: always
     ports:
       - 443:443

--- a/haproxy/haproxy.beta.cfg
+++ b/haproxy/haproxy.beta.cfg
@@ -7,6 +7,10 @@ defaults
 # frontend - client traffic
 frontend client
     bind *:80
+    # rate limiting, 75 requests per client within 10 seconds
+    stick-table type ipv6 size 100k expire 30s store http_req_rate(10s) # stores client's ip address, 100,000 records, expire in 30s
+    http-request track-sc0 src # adds the cilent into the stick table
+    http-request deny deny_status 429 if { sc_http_req_rate(0) gt 75 } # denies access if rate is greater than 75
 
     acl is_center hdr_beg(host) -i center-beta. # center-beta.stamford.dev
 
@@ -20,6 +24,8 @@ frontend client
 
     acl is_grafana hdr_beg(host) -i grafana-beta. #grafana-beta.stamford.dev
 
+    acl is_s3 hdr_beg(host) -i files-beta. #files-beta.stamford.dev
+
     acl is_review hdr_beg(host) -i reviews-beta. #reviews-beta.stamford.dev
 
     acl is_gateway hdr_beg(host) -i gateway-beta. #gateway-beta.stamford.dev
@@ -30,6 +36,7 @@ frontend client
     use_backend portainer if is_portainer
     use_backend admin if is_admin
     use_backend grafana if is_grafana
+    use_backend s3 if is_s3
     use_backend review if is_review
     use_backend gateway if is_gateway
 
@@ -58,6 +65,9 @@ backend portainer
 
 backend grafana
     server grafana grafana:3000
+
+backend s3
+    server s3api s3:8333
 
 backend review
     server review web:3000

--- a/haproxy/haproxy.prod.cfg
+++ b/haproxy/haproxy.prod.cfg
@@ -7,6 +7,10 @@ defaults
 # frontend - client traffic
 frontend client
     bind *:80
+    # rate limiting, 75 requests per client within 10 seconds
+    stick-table type ipv6 size 100k expire 30s store http_req_rate(10s) # stores client's ip address, 100,000 records, expire in 30s
+    http-request track-sc0 src # adds the cilent into the stick table
+    http-request deny deny_status 429 if { sc_http_req_rate(0) gt 75 } # denies access if rate is greater than 75
 
     acl is_center hdr_beg(host) -i center. # center.stamford.dev
 
@@ -26,6 +30,8 @@ frontend client
 
     acl is_gateway hdr_beg(host) -i gateway. #gateway.stamford.dev
 
+    acl is_s3 hdr_beg(host) -i files. #files.stamford.dev
+
     use_backend center-fe if is_center
     use_backend center-be if is_center_be
     use_backend prometheus if is_prometheus
@@ -33,6 +39,7 @@ frontend client
     use_backend admin if is_admin
     use_backend portainer if is_portainer
     use_backend grafana if is_grafana
+    use_backend s3 if is_s3
     use_backend review if is_review
     use_backend gateway if is_gateway
 
@@ -70,3 +77,5 @@ backend review
 
 backend gateway 
     server gateway api-gateway:8000
+backend s3
+    server s3api s3:8333

--- a/redis/docker-compose.yaml
+++ b/redis/docker-compose.yaml
@@ -1,6 +1,6 @@
 version: "3.8"
 networks:
-  stamford:
+  internal:
 
 services:
   redis:
@@ -10,4 +10,4 @@ services:
       - 6379:6379
     command: ["redis-server", "--requirepass", "${REDIS_PASSWORD}"]
     networks:
-      - stamford
+      - internal 

--- a/stamfordcenter/docker-compose.dev.yaml
+++ b/stamfordcenter/docker-compose.dev.yaml
@@ -3,10 +3,14 @@ networks:
   stamford:
     external: true
     name: haproxy_stamford
+  redis_internal:
+    external: true
+    name: redis_internal
 
 services:
   frontend:
     image: ghcr.io/stamford-syntax-club/stamfordcenter-frontend:b496e7830c0acb0aa8d55d98773268d532f649e3
+    container_name: center-fe
     restart: always
     networks:
       - stamford
@@ -15,14 +19,18 @@ services:
 
   backend:
     image: ghcr.io/stamford-syntax-club/stamfordcenter-backend:8400c90041e45a4d03a64219306b7e7613352c5e
+    container_name: center-be
+    restart: always
     networks:
       - stamford
+      - redis_internal
     ports:
       - 8080:${PORT}
     environment:
       - PORT=${PORT}
       - S3_ENDPOINT=${S3_ENDPOINT}
       - MONGODB_URI=${MONGODB_URI}
+      - REDIS_URL=${REDIS_URL}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_REGION=${AWS_REGION}

--- a/stamfordcenter/docker-compose.prod.yaml
+++ b/stamfordcenter/docker-compose.prod.yaml
@@ -3,10 +3,14 @@ networks:
   stamford:
     external: true
     name: haproxy_stamford
+  redis_internal:
+    external: true
+    name: redis_internal
 
 services:
   frontend:
     image: ghcr.io/stamford-syntax-club/stamfordcenter-frontend:b496e7830c0acb0aa8d55d98773268d532f649e3
+    container_name: center-fe
     restart: always
     networks:
       - stamford
@@ -15,14 +19,18 @@ services:
 
   backend:
     image: ghcr.io/stamford-syntax-club/stamfordcenter-backend:f619ad1f272f9bf8f04936d15a55dcc0c66f1fd3
+    container_name: center-be
+    restart: always
     networks:
       - stamford
+      - redis_internal
     ports:
       - 8080:${PORT}
     environment:
       - PORT=${PORT}
       - S3_ENDPOINT=${S3_ENDPOINT}
       - MONGODB_URI=${MONGODB_URI}
+      - REDIS_URL=${REDIS_URL}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_REGION=${AWS_REGION}

--- a/start_dev.sh
+++ b/start_dev.sh
@@ -9,14 +9,14 @@ docker compose -f s3/docker-compose.yaml up -d
 # start monitoring services
 docker compose -f monitoring/docker-compose.yaml up -d
 
+# start redis services
+docker compose -f redis/docker-compose.yaml up -d
+
 # start stamford center services (run .dev file)
 docker compose -f stamfordcenter/docker-compose.dev.yaml up -d
 
 # start admin services
 docker compose -f admin/docker-compose.yaml up -d
-
-# start redis services
-docker compose -f redis/docker-compose.yaml up -d
 
 # start portainer services
 docker compose -f portainer/docker-compose.yaml up -d

--- a/start_prod.sh
+++ b/start_prod.sh
@@ -9,11 +9,11 @@ docker compose -f s3/docker-compose.yaml up -d
 # start monitoring services
 docker compose -f monitoring/docker-compose.yaml up -d
 
-# start stamford center services (run .prod file)
-docker compose -f stamfordcenter/docker-compose.prod.yaml up -d
-
 # start redis services
 docker compose -f redis/docker-compose.yaml up -d
+
+# start stamford center services (run .prod file)
+docker compose -f stamfordcenter/docker-compose.prod.yaml up -d
 
 # start admin services
 docker compose -f admin/docker-compose.yaml up -d


### PR DESCRIPTION
There are a lot of stuff done in this PR. I put them all together just to avoid having 10+ PRs open.


## Configure HAProxy Rate Limiting
- To prevent potential DDoS attacks and keep the resource usage fair, we enforce a reasonably loose (in my opinion) restriction in our reverse proxy
- Each client can make up to 75 requests to our server within 10 seconds. If they reach this limit, the following response will be shown. They can make more requests again after 10 seconds
![image](https://github.com/stamford-syntax-club/infra/assets/92321280/7358eb81-c27b-41a9-85d1-9a598b054c75)


## Clean Docker Compose Files
- setup the container name to resolve the most annoying pain point that we need to copy the container id for reading its logs.
- but this PR only sets for mostly used services such as haproxy, stamfordcenter, and course compose services.

## Add direct file retrieval  from S3
- Added the anonymous identity in SeaweedFS S3 configuration with limited permission as shown:
```json
// file: s3/config.json
{
    "identities": [
        {
            "name": "anonymous",
            "actions": [
                "Read",
                "List"
            ]
        }
     ]
}
```
- Configure HAProxy to direct subdomain `files.` and `files-beta.` to s3 api server
- Example: https://files.stamford.dev/stamford-center/resources/2_2023_academic_calendar.pdf